### PR TITLE
Obtener expediente varibale incorrecta arreglada, actualizar expedien…

### DIFF
--- a/src/main/java/es/uma/informatica/ejb/AlumnosEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/AlumnosEJB.java
@@ -68,7 +68,7 @@ public class AlumnosEJB implements GestionAlumno {
 	}
 	@Override
 	public List<Alumno> obtenerAlumnos() {
-		TypedQuery<Alumno> query = em.createQuery("finAllAlumnos", Alumno.class);
+		TypedQuery<Alumno> query = em.createNamedQuery("finAllAlumnos", Alumno.class);
 
 		return query.getResultList();
 	}

--- a/src/main/java/es/uma/informatica/ejb/AsignaturaEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/AsignaturaEJB.java
@@ -76,7 +76,7 @@ public class AsignaturaEJB implements GestionAsignatura{
 	@Override
 	public List<Asignatura> obtenerAsignaturas() {
 		// TODO Auto-generated method stub
-		TypedQuery<Asignatura> query = em.createQuery("finAllAsignatura", Asignatura.class);
+		TypedQuery<Asignatura> query = em.createNamedQuery("finAllAsignatura", Asignatura.class);
 		return query.getResultList();
 	}
 	

--- a/src/main/java/es/uma/informatica/ejb/CentroEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/CentroEJB.java
@@ -62,7 +62,7 @@ public class CentroEJB implements GestionCentro {
 	@Override
 	public List<Centro> obtenerCentros() {
 		// TODO Auto-generated method stub
-		TypedQuery<Centro> query = em.createQuery("findAllCentros", Centro.class);
+		TypedQuery<Centro> query = em.createNamedQuery("findAllCentros", Centro.class);
 		return query.getResultList();
 	}
 }

--- a/src/main/java/es/uma/informatica/ejb/ClaseEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/ClaseEJB.java
@@ -3,9 +3,8 @@ package es.uma.informatica.ejb;
 
 import javax.persistence.EntityManager;
 
-import javax.persistence.PersistenceContext;
 
-import java.util.logging.Logger;
+import javax.persistence.PersistenceContext;
 
 import javax.ejb.Stateless;
 
@@ -17,7 +16,6 @@ import es.uma.informatica.jpa.demo.*;
 @Stateless
 public class ClaseEJB implements GestionClase {
 	
-	private static final Logger LOG = Logger.getLogger(ClaseEJB.class.getCanonicalName());
 	@PersistenceContext(name= "Secretaria")
 	private EntityManager em;
 	

--- a/src/main/java/es/uma/informatica/ejb/EncuestaEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/EncuestaEJB.java
@@ -3,26 +3,21 @@ package es.uma.informatica.ejb;
 
 import javax.persistence.EntityManager;
 
+
 import javax.persistence.PersistenceContext;
 
 import java.sql.Timestamp;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
-import java.util.logging.Logger;
 
 import javax.ejb.Stateless;
 
-import es.uma.informatica.ejb.exceptions.ClaseNoEncontradaException;
 import es.uma.informatica.ejb.exceptions.EncuestaNoEncontradaException;
 import es.uma.informatica.ejb.exceptions.EncuestaYaExistenteException;
-import es.uma.informatica.ejb.exceptions.ProyectoException;
 import es.uma.informatica.jpa.demo.*;
 
 
 @Stateless
 public class EncuestaEJB implements GestionEncuesta {
 	
-	private static final Logger LOG = Logger.getLogger(EncuestaEJB.class.getCanonicalName());
 	@PersistenceContext(name= "Secretaria")
 	private EntityManager em;
 	

--- a/src/main/java/es/uma/informatica/ejb/ExpedienteEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/ExpedienteEJB.java
@@ -1,11 +1,11 @@
 package es.uma.informatica.ejb;
  
 import javax.persistence.EntityManager;
+
 import javax.persistence.PersistenceContext;
-import javax.persistence.Query;
- 
+import javax.persistence.TypedQuery;
+
 import java.util.List;
-import java.util.logging.Logger;
  
 import javax.ejb.Stateless;
 
@@ -36,11 +36,11 @@ public class ExpedienteEJB implements GestionExpediente{
     @Override
     public Expediente obtenerExpediente(Integer numExpediente) throws ExpedienteNoEncontradoException {
         // TODO Auto-generated method stub
-    	Query  expedientes = em.createQuery("Select e from Expediente e where e.numExpediente = :numExpediente" );
+    	TypedQuery<Expediente>  expedientes = em.createQuery("Select e from Expediente e where e.numExpediente = :numExpediente" ,Expediente.class);
 		expedientes.setParameter("numExpediente", numExpediente);
 		List<Expediente> expediente = expedientes.getResultList();
 		Expediente ex = expediente.get(0);
-		if(expediente == null) throw new ExpedienteNoEncontradoException();
+		if(ex == null) throw new ExpedienteNoEncontradoException();
 		
 		return ex;
     }
@@ -58,7 +58,7 @@ public class ExpedienteEJB implements GestionExpediente{
     @Override
     public void actualizarExpediente(Expediente expediente) throws ExpedienteNoEncontradoException {
         // TODO Auto-generated method stub
-        Expediente exp = em.find(Expediente.class, expediente.getNumExpediente());
+        Expediente exp = obtenerExpediente(expediente.getNumExpediente());
         exp.setNotaMediaProvisional(expediente.getNotaMediaProvisional());
         exp.setActivo(expediente.getActivo());
         em.merge(exp);
@@ -67,8 +67,8 @@ public class ExpedienteEJB implements GestionExpediente{
     @Override
     public List<Expediente> obtenerExpedientes() {
         // TODO Auto-generated method stub
-        List<Expediente> exp = em.createQuery("Select * from Expediente").getResultList();
-        return exp;
+    	TypedQuery<Expediente> query = em.createNamedQuery("findAllExpedientes", Expediente.class);
+        return query.getResultList();
     }
     
     

--- a/src/main/java/es/uma/informatica/ejb/GrupoEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/GrupoEJB.java
@@ -39,7 +39,7 @@ public class GrupoEJB implements GestionGrupo{
         grupos.setParameter("plazas", plazas);
         List<Grupo> grupo = grupos.getResultList();
         Grupo gru = grupo.get(0);
-		if(grupo == null) {
+		if(gru == null) {
             throw new GrupoNoEncontradoException();
         }
         return gru;
@@ -55,8 +55,8 @@ public class GrupoEJB implements GestionGrupo{
 	@Override
 	public List<Grupo> obtenerGrupos() {
 		// TODO Auto-generated method stub
-		List<Grupo> grup = em.createQuery("Select * from Grupo").getResultList();
-		return grup;
+		TypedQuery<Grupo> query = em.createNamedQuery("findAllGrupos", Grupo.class);
+		return query.getResultList();
 	}
 
 	@Override

--- a/src/main/java/es/uma/informatica/ejb/MatriculaEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/MatriculaEJB.java
@@ -71,7 +71,7 @@ public class MatriculaEJB implements GestionMatricula {
 	
 	@Override
 	public List<Matricula> obtenerMatriculas() {
-		TypedQuery<Matricula> query = em.createQuery("finAllMatricula", Matricula.class);
+		TypedQuery<Matricula> query = em.createNamedQuery("finAllMatricula", Matricula.class);
 		return query.getResultList();
 	}
 	

--- a/src/main/java/es/uma/informatica/ejb/OptativaEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/OptativaEJB.java
@@ -5,7 +5,8 @@ import java.util.List;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
- 
+import javax.persistence.TypedQuery;
+
 import es.uma.informatica.ejb.exceptions.OptativaNoEncontradoException;
 import es.uma.informatica.ejb.exceptions.OptativaYaExistenteException;
 import es.uma.informatica.jpa.demo.Optativa;
@@ -40,8 +41,8 @@ public class OptativaEJB implements GestionOptativa{
         em.remove(opt);
     }
     public List<Optativa> obtenerOptativas(){
-        List<Optativa> opt = em.createQuery("Select * from Optativa").getResultList();
-        return opt;
+    	TypedQuery<Optativa> query = em.createNamedQuery("findAllOptativas", Optativa.class); 
+        return query.getResultList();
     }
     public void actualizarOptativa(Optativa optativa) throws OptativaNoEncontradoException{
         Optativa opt = em.find(Optativa.class, optativa.getReferencia());

--- a/src/main/java/es/uma/informatica/ejb/TitulacionEJB.java
+++ b/src/main/java/es/uma/informatica/ejb/TitulacionEJB.java
@@ -1,18 +1,19 @@
 package es.uma.informatica.ejb;
 
 import java.io.IOException;
+
 import java.util.List;
 
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
 
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import es.uma.informatica.ejb.exceptions.TitulacionNoEncontradaException;
 import es.uma.informatica.ejb.exceptions.TitulacionYaExistenteException;
-import es.uma.informatica.jpa.demo.Alumno;
 import es.uma.informatica.jpa.demo.Titulacion;
 
 @Stateless
@@ -43,7 +44,7 @@ public class TitulacionEJB implements GestionTitulacion {
 	@Override
 	public void eliminarTitulacion(Integer codigo) throws TitulacionNoEncontradaException {
 		// TODO Auto-generated method stub
-		Titulacion titulacion = em.find(Titulacion.class, codigo);
+		Titulacion titulacion = obtenerTitulacion(codigo);
 		if(titulacion == null)
 			throw new TitulacionNoEncontradaException();
 		em.remove(titulacion);
@@ -52,7 +53,7 @@ public class TitulacionEJB implements GestionTitulacion {
 	@Override
 	public void actualizarTitulacion(Titulacion titulacion) throws TitulacionNoEncontradaException {
 		// TODO Auto-generated method stub
-		Titulacion tit = em.find(Titulacion.class, titulacion.getCodigo());
+		Titulacion tit = obtenerTitulacion(titulacion.getCodigo());
 		tit.setCodigo(titulacion.getCodigo());
 		tit.setCreditos(titulacion.getCreditos());
 		tit.setNombre(titulacion.getNombre());
@@ -62,8 +63,8 @@ public class TitulacionEJB implements GestionTitulacion {
 	@Override
 	public List<Titulacion> obtenerTitulaciones() {
 		// TODO Auto-generated method stub
-		List<Titulacion> titulaciones = em.createQuery("Select tit from Titulacion tit").getResultList();
-		return titulaciones;
+		TypedQuery<Titulacion> query = em.createNamedQuery("findAllTitulaciones", Titulacion.class);
+		return query.getResultList();
 	}
 
 	@Override

--- a/src/main/java/es/uma/informatica/jpa/demo/Expediente.java
+++ b/src/main/java/es/uma/informatica/jpa/demo/Expediente.java
@@ -6,9 +6,11 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 
 @Entity
+@NamedQuery(name = "findAllExpedientes", query = "select exp from Expediente exp")
 public class Expediente {
 
 	@Id

--- a/src/main/java/es/uma/informatica/jpa/demo/Grupo.java
+++ b/src/main/java/es/uma/informatica/jpa/demo/Grupo.java
@@ -7,9 +7,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 
 @Entity
+@NamedQuery(name = "findAllGrupos", query = "select grp from Grupo grp")
 public class Grupo {
 	
 	@Id 

--- a/src/main/java/es/uma/informatica/jpa/demo/Optativa.java
+++ b/src/main/java/es/uma/informatica/jpa/demo/Optativa.java
@@ -2,10 +2,16 @@ package es.uma.informatica.jpa.demo;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.NamedQuery;
 
 @Entity
+@NamedQuery(name = "findAllOptativas", query = "select opt from Optativa opt")
 public class Optativa extends Asignatura {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
 	@Column(name = "Plazas")
 	private Integer plazas;
 	@Column(name = "Mencion", length = 20)

--- a/src/main/java/es/uma/informatica/jpa/demo/Titulacion.java
+++ b/src/main/java/es/uma/informatica/jpa/demo/Titulacion.java
@@ -9,9 +9,13 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 
 @Entity
+@NamedQueries( { @NamedQuery (name = "findAllTitulaciones", query = "select tit from Titulacion tit") })
+
 public class Titulacion implements Serializable {
 
 	/**

--- a/src/test/java/es/uma/informatica/jpa/demo/ejb/practica/Sample_Alumno.java
+++ b/src/test/java/es/uma/informatica/jpa/demo/ejb/practica/Sample_Alumno.java
@@ -123,6 +123,15 @@ public class Sample_Alumno {
 			throw new RunLevelException(e);
 		}
 	}
+	
+	@Test
+	public void testObteneralumnos() {
+		try {
+			gestionAlumno.obtenerAlumnos();
+		}catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
 
 }
 	


### PR DESCRIPTION
…te usando el metodo ya creado de obtener expediente pasar cubrir el posible error, obtener lista de entidades completas cambiadas de consultas query a TypedQuery en expediente, grupo, optativas y titulaciones y agregados los NamedQuerys findAll de expediente, grupo, optativa y titulacion.(Todos los obtener's han sido cambiado de createQuery a createNamedQuery no encontraba la consulta y daba error, ya no). Todas las advertencias de los EJB están quitadas y creado el test de obtenerAlumnos.